### PR TITLE
Improve region resolving

### DIFF
--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/mfa/SessionCache.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/mfa/SessionCache.java
@@ -26,7 +26,7 @@ package com.schibsted.security.strongbox.cli.mfa;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.securitytoken.model.AssumedRoleUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.schibsted.security.strongbox.cli.types.ProfileIdentifier;
+import com.schibsted.security.strongbox.sdk.types.ProfileIdentifier;
 
 import java.io.File;
 import java.io.IOException;

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/exceptions/FailedToResolveRegionException.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/exceptions/FailedToResolveRegionException.java
@@ -21,17 +21,18 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.schibsted.security.strongbox.cli.types;
+package com.schibsted.security.strongbox.sdk.exceptions;
 
 /**
- * AWS profile used in AWS CLI credential and config files
- *
  * @author stiankri
  */
-public class ProfileIdentifier {
-    public final String name;
+public class FailedToResolveRegionException extends RuntimeException {
 
-    public ProfileIdentifier(final String name) {
-        this.name = name;
+    public FailedToResolveRegionException(String message) {
+        super(message);
+    }
+
+    public FailedToResolveRegionException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFile.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFile.java
@@ -21,7 +21,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.schibsted.security.strongbox.cli.config;
+package com.schibsted.security.strongbox.sdk.internal.config;
+
+import com.amazonaws.profile.path.AwsProfileFileLocationProvider;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -140,5 +142,13 @@ public class AWSCLIConfigFile {
             this.key = key;
             this.value = value;
         }
+    }
+
+    public static Optional<File> getCredentialProfilesFile() {
+        return Optional.ofNullable(AwsProfileFileLocationProvider.DEFAULT_CREDENTIALS_LOCATION_PROVIDER.getLocation());
+    }
+
+    public static Optional<File> getConfigFile() {
+        return Optional.ofNullable(AwsProfileFileLocationProvider.DEFAULT_CONFIG_LOCATION_PROVIDER.getLocation());
     }
 }

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/CustomRegionProviderChain.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/CustomRegionProviderChain.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Schibsted Products & Technology AS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.schibsted.security.strongbox.sdk.internal.config;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.util.EC2MetadataUtils;
+import com.schibsted.security.strongbox.sdk.exceptions.FailedToResolveRegionException;
+import com.schibsted.security.strongbox.sdk.types.ProfileIdentifier;
+import com.schibsted.security.strongbox.sdk.types.Region;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * @author stiankri
+ */
+public class CustomRegionProviderChain {
+
+    public Region resolveRegion() {
+        return resolveRegion(Optional.empty(), Optional.empty());
+    }
+
+    // https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#automatically-determine-the-aws-region-from-the-environment
+    public Region resolveRegion(Optional<String> region, Optional<ProfileIdentifier> profile) {
+        Optional<Region> resolvedRegion = Optional.empty();
+
+        if (region.isPresent()) {
+            resolvedRegion = Optional.of(Region.fromName(region.get()));
+        }
+        if (!resolvedRegion.isPresent()){
+            resolvedRegion = getRegionFromEnvironment();
+        }
+        if (!resolvedRegion.isPresent()){
+            resolvedRegion = getRegionFromProfile(profile);
+        }
+        if (!resolvedRegion.isPresent()){
+            resolvedRegion = getRegionFromMetadata();
+        }
+
+        if (!resolvedRegion.isPresent()) {
+            throw new FailedToResolveRegionException("A region must be specified");
+        }
+
+        return resolvedRegion.get();
+    }
+
+    private Optional<Region> getRegionFromEnvironment() {
+        Region resolvedRegion = null;
+        if (System.getenv("AWS_REGION") != null) {
+            resolvedRegion = Region.fromName(System.getenv("AWS_REGION"));
+        } else if (System.getenv("AWS_DEFAULT_REGION") != null) {
+            resolvedRegion = Region.fromName(System.getenv("AWS_DEFAULT_REGION"));
+        }
+        return Optional.ofNullable(resolvedRegion);
+    }
+
+    private Optional<Region> getRegionFromProfile(Optional<ProfileIdentifier> profile) {
+        String profileInConfig = profile.map(p -> p.name).orElse("default");
+        return getDefaultRegionFromConfigFile(profileInConfig);
+    }
+
+    private Optional<Region> getRegionFromMetadata() {
+        try {
+            Region resolvedRegion = null;
+            if (EC2MetadataUtils.getInstanceInfo() != null) {
+                if (EC2MetadataUtils.getInstanceInfo().getRegion() != null) {
+                    resolvedRegion = Region.fromName(EC2MetadataUtils.getInstanceInfo().getRegion());
+                } else { // fallback to provider chain if region is not exposed
+                    resolvedRegion = Region.fromName(new DefaultAwsRegionProviderChain().getRegion());
+                }
+            }
+            return Optional.ofNullable(resolvedRegion);
+        } catch (SdkClientException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Region> getDefaultRegionFromConfigFile(String profile) {
+
+        Optional<String> region = AWSCLIConfigFile.getCredentialProfilesFile()
+                .flatMap(file -> getRegionFromConfigFile(file, profile));
+
+        if (!region.isPresent()) {
+            region = AWSCLIConfigFile.getConfigFile()
+                    .flatMap(file -> getRegionFromConfigFile(file, profile));
+        }
+
+        return region.map(Region::fromName);
+    }
+
+    private static Optional<String> getRegionFromConfigFile(File file, String profile) {
+        AWSCLIConfigFile configFile = new AWSCLIConfigFile(file);
+        AWSCLIConfigFile.Config config = configFile.getConfig();
+
+        Optional<AWSCLIConfigFile.Section> profileSection = config.getSection(profile);
+
+        // Legacy fallback
+        if (!profileSection.isPresent()) {
+            profileSection = config.getSection("profile " + profile);
+        }
+
+        return profileSection.flatMap(s -> s.getProperty("region"));
+    }
+}

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/types/ProfileIdentifier.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/types/ProfileIdentifier.java
@@ -21,25 +21,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.schibsted.security.strongbox.cli.mfa;
-
-import com.schibsted.security.strongbox.sdk.types.ProfileIdentifier;
-import org.testng.annotations.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+package com.schibsted.security.strongbox.sdk.types;
 
 /**
+ * AWS profile used in AWS CLI credential and config files
+ *
  * @author stiankri
  */
-public class SessionCacheTest {
-    @Test
-    public void resolve_filename() {
-        ProfileIdentifier profile = new ProfileIdentifier("my-profile");
-        String arn = "arn:test/dummy";
+public class ProfileIdentifier {
+    public final String name;
 
-        SessionCache sessionCache = new SessionCache(profile, arn);
-
-        assertThat(sessionCache.resolveFileName(), is("my-profile--arn_test-dummy.json"));
+    public ProfileIdentifier(final String name) {
+        this.name = name;
     }
 }

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFileTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFileTest.java
@@ -21,7 +21,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.schibsted.security.strongbox.cli.config;
+package com.schibsted.security.strongbox.sdk.internal.config;
 
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
 - Share region resolving between SDK and CLI
 - Cache resolved region
 - Fail hard for CLI, fallback to default region for SDK

These changes are to improve the workaround that was created when region was no longer implicit when making calls to AWS.