### PR TITLE
Hide stack traces in CLI by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 .gnupg/
 .gradle/
-*.idea/
-*.iml
 build/
 bin/
 lib/
 *.sbx
 .secrets/signing_key.asc
 bintray/
+
+# Intellij
+*.idea/
+*.iml
+sdk/out
+cli/out
+archaius/out

--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/view/Global.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/view/Global.java
@@ -64,6 +64,9 @@ public class Global {
         @io.airlift.airline.Option(type = OptionType.GLOBAL, name = Option.Constants.AES_256, description = Option.Constants.AES_256_DESCRIPTION)
         public boolean useAES256;
 
+        @io.airlift.airline.Option(type = OptionType.GLOBAL, name = Option.Constants.STACKTRACE, description = Option.Constants.STACKTRACE_DESCRIPTION)
+        public boolean stacktrace;
+
         protected GroupModel groupModel() {
             if (!this.groupModel.isPresent()) {
                 this.groupModel = Optional.of(new GroupModel(profile, role, region, useAES256, outputFormat, fieldName, outputPath));
@@ -98,6 +101,7 @@ public class Global {
             System.out.println(String.format("strongbox version '%s'", version));
         }
     }
+
 
     public enum Option {
         ASSUME_ROLE(Constants.ASSUME_ROLE, Constants.ASSUME_ROLE_DESCRIPTION),
@@ -156,6 +160,9 @@ public class Global {
 
             static final String VERSION = "--version";
             static final String VERSION_DESCRIPTION = "Display version information";
+
+            static final String STACKTRACE = "--stacktrace";
+            static final String STACKTRACE_DESCRIPTION = "Print out stacktrace for exceptions";
         }
     }
 }


### PR DESCRIPTION
 * use the global option '--stacktrace' to show it