### PR TITLE
Handle missing secret in InMemoryPlaintextSecret.

### DIFF
--- a/archaius/src/main/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecret.java
+++ b/archaius/src/main/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecret.java
@@ -4,49 +4,20 @@
 
 package com.schibsted.security.strongbox.archaius;
 
-import com.netflix.config.DynamicStringProperty;
 import com.schibsted.security.strongbox.sdk.SecretsGroup;
 import com.schibsted.security.strongbox.sdk.types.SecretIdentifier;
 
-import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Holds the decrypted secret in-memory. The secret will only be decrypted once per time it changes.
  * This is useful if you do not want the overhead of just-in-time decryption.
  *
  * @author stiankri
+ * @author zamzterz
  */
-public class InMemoryPlaintextSecret extends DynamicStringProperty {
-    private Optional<String> value = Optional.empty();
-    private final SecretsGroup secretsGroup;
-    private final SecretIdentifier secretIdentifier;
-
+public class InMemoryPlaintextSecret extends InMemoryPlaintextSecretDerived<String> {
     public InMemoryPlaintextSecret(SecretsGroup secretsGroup, SecretIdentifier secretIdentifier) {
-        // Please note: null is used as the default value, as it generally does not make sense to have a default secret
-        super(secretsGroup.srn(secretIdentifier).toSrn(), null);
-        this.secretsGroup = secretsGroup;
-        this.secretIdentifier = secretIdentifier;
-        addCallback(callback());
-    }
-
-    // TODO synchronize?
-    Runnable callback() {
-      return () -> {
-          value = Optional.of(DecryptSecret.fromJsonBlob(super.get(), secretsGroup, secretIdentifier));
-        };
-    }
-
-    /**
-     * Get the secret kept in-memory.
-     *
-     * @return The decrypted secret as a {@code String}, or {@code null}
-     */
-    @Override
-    public String get() {
-        if (!value.isPresent()) {
-            callback().run();
-        }
-
-        return value.get();
+        super(secretsGroup, secretIdentifier, Function.identity());
     }
 }

--- a/archaius/src/main/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecretDerived.java
+++ b/archaius/src/main/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecretDerived.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
  */
 public class InMemoryPlaintextSecretDerived<T> extends StringDerivedProperty<T> {
     public InMemoryPlaintextSecretDerived(SecretsGroup secretsGroup, SecretIdentifier secretIdentifier, Function<String, T> decoder) {
+        // Please note: null is used as the default value, as it generally does not make sense to have a default secret
         super(secretsGroup.srn(secretIdentifier).toSrn(),
                 null,
                 value -> decoder.apply(DecryptSecret.fromJsonBlob(value, secretsGroup, secretIdentifier)));

--- a/archaius/src/test/java/com/schibsted/security/strongbox/archaius/ArchaiusTestBase.java
+++ b/archaius/src/test/java/com/schibsted/security/strongbox/archaius/ArchaiusTestBase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Schibsted Products & Technology AS. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+ */
+
+package com.schibsted.security.strongbox.archaius;
+
+import com.netflix.config.ConfigurationManager;
+import com.schibsted.security.strongbox.sdk.SecretsGroup;
+import com.schibsted.security.strongbox.sdk.internal.impl.DefaultSecretsGroup;
+import com.schibsted.security.strongbox.sdk.types.SRN;
+import com.schibsted.security.strongbox.sdk.types.SecretIdentifier;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author zamzterz
+ */
+public class ArchaiusTestBase {
+    protected final SecretIdentifier secretIdentifier = new SecretIdentifier("test_secret_name");
+    protected SecretsGroup mockSecretsGroup;
+
+    @BeforeMethod
+    public void setUp() {
+        mockSecretsGroup = mock(DefaultSecretsGroup.class);
+        SRN mockSRN = mock(SRN.class);
+        when(mockSRN.toSrn()).thenReturn(secretIdentifier.name);
+        when(mockSecretsGroup.srn(secretIdentifier)).thenReturn(mockSRN);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        ConfigurationManager.getConfigInstance().clearProperty(secretIdentifier.name);
+    }
+}

--- a/archaius/src/test/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecretTest.java
+++ b/archaius/src/test/java/com/schibsted/security/strongbox/archaius/InMemoryPlaintextSecretTest.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2017 Schibsted Media Group. All rights reserved.
+ * Copyright (c) 2017 Schibsted Products & Technology AS. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
  */
+
 package com.schibsted.security.strongbox.archaius;
 
 import com.netflix.config.ConfigurationManager;
@@ -12,13 +13,20 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 /**
  * @author zamzterz
  */
-public class InMemoryPlaintextSecretDerivedTest extends ArchaiusTestBase {
+public class InMemoryPlaintextSecretTest extends ArchaiusTestBase {
     @Test
-    public void testSecretIsDecryptedBeforeBeingPassedToDecoder() {
+    public void testMissingSecretResultsInNull() {
+        InMemoryPlaintextSecret p = new InMemoryPlaintextSecret(mockSecretsGroup, secretIdentifier);
+        assertNull(p.getValue());
+    }
+
+    @Test
+    public void testSecretIsDecrypted() {
         String secretValue = "test_secret_value";
         long version = 1;
         RawSecretEntry rawSecret = new RawSecretEntry(secretIdentifier,
@@ -30,10 +38,8 @@ public class InMemoryPlaintextSecretDerivedTest extends ArchaiusTestBase {
         SecretEntry secretEntry = new SecretEntryMock.Builder().secretValue(secretValue).build();
         when(mockSecretsGroup.decrypt(rawSecret, secretIdentifier, version)).thenReturn(secretEntry);
 
-        InMemoryPlaintextSecretDerived<Integer> p = new InMemoryPlaintextSecretDerived<>(mockSecretsGroup,
-                secretIdentifier,
-                String::length);
+        InMemoryPlaintextSecret p = new InMemoryPlaintextSecret(mockSecretsGroup, secretIdentifier);
         ConfigurationManager.getConfigInstance().setProperty(secretIdentifier.name, rawSecret.toJsonBlob());
-        assertEquals(p.getValue().intValue(), secretValue.length());
+        assertEquals(p.getValue(), secretValue);
     }
 }


### PR DESCRIPTION
Simplify the implementation by using existing functionality from
StringDerivedProperty to decrypt the secret each time it changes.

*Previous implementation resulted in a `NullPointerException` being thrown for the test `testMissingSecretResultsInNull`, and could result in a corrupted value for the test in `testSecretIsDecrypted`.*