### PR TITLE
Debian should default to amd64 arch

### DIFF
--- a/repo/src/main/resources/deb/etc/apt/sources.list.d/strongbox.list
+++ b/repo/src/main/resources/deb/etc/apt/sources.list.d/strongbox.list
@@ -1,1 +1,1 @@
-deb http://dl.bintray.com/strongbox/strongbox-deb debian main
+deb [arch=amd64] http://dl.bintray.com/strongbox/strongbox-deb debian main


### PR DESCRIPTION
Fixes #68 