### PR TITLE
Cleanup of how hash functions are used

### DIFF
--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/encryption/EncryptionPayload.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/encryption/EncryptionPayload.java
@@ -72,37 +72,6 @@ public class EncryptionPayload implements BestEffortShred {
         }
     }
 
-    public static byte[] computeSHA(State state, Optional<ZonedDateTime> notBefore, Optional<ZonedDateTime> notAfter) {
-        try {
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-
-            messageDigest.update(state.asByte());
-            messageDigest.update(toByteArray(notBefore));
-            messageDigest.update(toByteArray(notAfter));
-
-            return messageDigest.digest();
-        } catch (NoSuchAlgorithmException e) {
-            throw new SerializationException("Failed to get SHA for encryption payload", e);
-        }
-    }
-
-    private static byte[] toByteArray(Optional<ZonedDateTime> date) {
-        ByteBuffer buffer = ByteBuffer.allocate(9);
-        if (date.isPresent()) {
-            buffer.put((byte)1);
-            buffer.putLong(FormattedTimestamp.epoch(date.get()));
-        } else {
-            buffer.put((byte)0);
-            buffer.putLong(0);
-        }
-        return buffer.array();
-    }
-
-    public static boolean verifyDataIntegrity(State state, Optional<ZonedDateTime> notBefore, Optional<ZonedDateTime> notAfter, byte[] sha) {
-        return Arrays.equals(computeSHA(state, notBefore, notAfter), sha);
-    }
-
-
     public byte[] toByteArray() {
         byte[] userData = extractByteArray(this.userData.map(UserData::asByteArray));
         byte[] comment = extractByteArray(this.comment.map(Comment::asByteArray));

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDB.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDB.java
@@ -369,9 +369,19 @@ public class GenericDynamoDB<Entry, Primary> implements GenericStore<Entry, Prim
         return expected;
     }
 
+    /**
+     * We can use the sha1 of the encryption payload as the key for the whole Entry because
+     * the encryption payload contains both the encrypted data as well as the encryption context
+     * which in turn contains the rest of the data in the Entry. This is due to how the AWS
+     * Encryption SDK is implemented. This implicit nature is unfortunate as it is not obvious
+     * and it relies on the AWS Encryption SDK to keep this behaviour.
+     *
+     * @param entry RawSecretEntry
+     * @return sha1 of entry
+     */
     private String sha(Entry entry) {
         RawSecretEntry rse = (RawSecretEntry) entry;
-        return Encoder.base64encode(rse.sha1OfEncryptionPayload());
+        return rse.sha1OfEncryptionPayload();
     }
 
     private Map<String, AttributeValueUpdate> createAttributes(Entry entry) {

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/types/RawSecretEntry.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/types/RawSecretEntry.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.schibsted.security.strongbox.sdk.internal.converter.Encoder;
 import com.schibsted.security.strongbox.sdk.internal.encryption.BestEffortShred;
 import com.schibsted.security.strongbox.sdk.internal.encryption.BestEffortShredder;
 import com.schibsted.security.strongbox.sdk.exceptions.ParseException;
@@ -97,14 +98,13 @@ public final class RawSecretEntry implements BestEffortShred {
         }
     }
 
-    public byte[] sha1OfEncryptionPayload() {
-        try {
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA");
-            messageDigest.update(encryptedPayload);
-            return messageDigest.digest();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Failed to compute sha1 of encryption payload", e);
-        }
+    /**
+     * This method is used for optimistic locking and not for security purposes
+     *
+     * @return sha1 of encryptedPayload
+     */
+    public String sha1OfEncryptionPayload() {
+        return Encoder.sha1(encryptedPayload);
     }
 
     @Override

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/converter/EncoderTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/converter/EncoderTest.java
@@ -1,0 +1,36 @@
+package com.schibsted.security.strongbox.sdk.internal.converter;
+
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author stiankri
+ */
+public class EncoderTest {
+    @Test
+    public void asUTF8() {
+        assertThat(Encoder.asUTF8("aB"), is(new byte[]{97, 66}));
+    }
+
+    @Test
+    public void fromUTF8() {
+        assertThat(Encoder.fromUTF8(new byte[]{97, 66}), is("aB"));
+    }
+
+    @Test
+    public void base64_encode() {
+        assertThat(Encoder.base64encode(new byte[]{65}), is("QQ=="));
+    }
+
+    @Test
+    public void base64_decode() {
+        assertThat(Encoder.base64decode("QQ=="), is(new byte[]{65}));
+    }
+
+    @Test
+    public void sha1() {
+        assertThat(Encoder.sha1(Encoder.asUTF8("test")), is("qUqP5cyxm6YcTAhz05Hph5gvu9M="));
+    }
+}

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/encryption/EncryptionPayloadTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/encryption/EncryptionPayloadTest.java
@@ -146,14 +146,6 @@ public class EncryptionPayloadTest {
     }
 
     @Test
-    public void ensureNotCommutative() {
-        byte[] sha1 = EncryptionPayload.computeSHA(State.ENABLED, notAfter, Optional.empty());
-        byte[] sha2 = EncryptionPayload.computeSHA(State.ENABLED, Optional.empty(), notAfter);
-
-        assertNotEquals(sha1, sha2, "Should not be able to reorder and have the same hash");
-    }
-
-    @Test
     public void testEquals() {
         EncryptionPayload samePayload = new EncryptionPayload(value, userData, created, createdBy, modified,
                 modifiedBy, comment);

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDBTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDBTest.java
@@ -138,7 +138,7 @@ public class GenericDynamoDBTest {
                 new AttributeValueUpdate()
                         .withAction(AttributeAction.PUT)
                         .withValue(new AttributeValue()
-                                .withS(Encoder.base64encode(rawSecretEntry.sha1OfEncryptionPayload()))));
+                                .withS(rawSecretEntry.sha1OfEncryptionPayload())));
 
         // Create the expected conditions map.
         Map<String, ExpectedAttributeValue> expected = new HashMap<>();
@@ -146,7 +146,7 @@ public class GenericDynamoDBTest {
             expected.put(KEY_ATTRIBUTE_NAME.toString(), new ExpectedAttributeValue(true).withValue(
                     new AttributeValue(rawSecretEntry.secretIdentifier.name)));
             expected.put(OPTIMISTIC_LOCKING_ATTRIBUTE_NAME, new ExpectedAttributeValue(true).withValue(
-                    new AttributeValue(Encoder.sha1(expectedRawSecretEntry.get().encryptedPayload))));
+                    new AttributeValue(expectedRawSecretEntry.get().sha1OfEncryptionPayload())));
         } else {
             expected.put(KEY_ATTRIBUTE_NAME.toString(), new ExpectedAttributeValue(false));
         }

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/types/RawSecretEntryTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/types/RawSecretEntryTest.java
@@ -50,6 +50,11 @@ public class RawSecretEntryTest {
     }
 
     @Test
+    public void sha1() {
+        assertThat(rawSecretEntry.sha1OfEncryptionPayload(), is(Encoder.sha1(rawSecretEntry.encryptedPayload)));
+    }
+
+    @Test
     public void equals() {
         // Wrong type.
         assertFalse(rawSecretEntry.equals(secretIdentifier));


### PR DESCRIPTION
This is an attempt to clean up the use of hash functions in the project. The only current use is for optimistic locking in DynamoDB. It was not immediately clear why the current implementation made sense, and there was also an instance of unused sha256 and a duplicate sha128. This PR attempts to improve the situation. 