### PR TITLE
Increase create/delete timeout for DynamoDB tables

### DIFF
--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDB.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/kv4j/generic/backend/dynamodb/GenericDynamoDB.java
@@ -78,7 +78,7 @@ import java.util.stream.Stream;
  */
 public class GenericDynamoDB<Entry, Primary> implements GenericStore<Entry, Primary>, ManagedResource, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(GenericDynamoDB.class);
-    private static final int SLEEP_TIME = 500;
+    private static final int SLEEP_TIME = 5000;
     private static final int MAX_RETRIES = 30;
 
     private AmazonDynamoDB client;


### PR DESCRIPTION
By increasing SLEEP_TIMEOUT to 5 seconds, we accomplish two things:

- Timeout for create/delete operations increases from 15s to 2.5 minutes
- Output from CLI is less spammy, logging only every 5s instead of 0.5s

This should help avoid timeouts in most cases. Fixes #74.