### PR TITLE
Remove NUL padding when reading secrets from stdin

### DIFF
--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
@@ -168,10 +168,13 @@ public class SecretModel implements AutoCloseable {
     private byte[] asBytes(char[] chars) {
         CharBuffer charBuffer = CharBuffer.wrap(chars);
         ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
+        byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
 
         BestEffortShredder.shred(chars);
+        BestEffortShredder.shred(charBuffer.array());
+        BestEffortShredder.shred(byteBuffer.array());
 
-        return Arrays.copyOf(byteBuffer.array(), byteBuffer.limit());
+        return bytes;
     }
 
     private static int booleanIfExists(String value) {

--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
@@ -37,7 +37,6 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -145,7 +144,7 @@ public class SecretModel implements AutoCloseable {
                 if (secretValue == null) {
                     throw new IllegalArgumentException("A secret value must be specified");
                 }
-                return asBytes(secretValue);
+                return SecretValueConverter.asBytes(secretValue);
             } else {
                 // Piped in
                 return IOUtils.toByteArray(inputStream);
@@ -163,17 +162,6 @@ public class SecretModel implements AutoCloseable {
         } catch (IOException e) {
             throw new RuntimeException(String.format("Failed to read secret value from file '%s'", valueFile), e);
         }
-    }
-
-    private byte[] asBytes(char[] chars) {
-        CharBuffer charBuffer = CharBuffer.wrap(chars);
-        ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
-        byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
-
-        BestEffortShredder.shred(charBuffer.array());
-        BestEffortShredder.shred(byteBuffer.array());
-
-        return bytes;
     }
 
     private static int booleanIfExists(String value) {

--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -170,7 +171,7 @@ public class SecretModel implements AutoCloseable {
 
         BestEffortShredder.shred(chars);
 
-        return byteBuffer.array();
+        return Arrays.copyOf(byteBuffer.array(), byteBuffer.limit());
     }
 
     private static int booleanIfExists(String value) {

--- a/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
+++ b/cli/src/main/java/com/schibsted/security/strongbox/cli/viewmodel/SecretModel.java
@@ -170,7 +170,6 @@ public class SecretModel implements AutoCloseable {
         ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
         byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
 
-        BestEffortShredder.shred(chars);
         BestEffortShredder.shred(charBuffer.array());
         BestEffortShredder.shred(byteBuffer.array());
 

--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/converter/SecretValueConverter.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/converter/SecretValueConverter.java
@@ -8,6 +8,9 @@ import com.schibsted.security.strongbox.sdk.internal.encryption.BestEffortShredd
 import com.schibsted.security.strongbox.sdk.types.SecretType;
 import com.schibsted.security.strongbox.sdk.types.SecretValue;
 
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 /**
@@ -27,5 +30,16 @@ public class SecretValueConverter {
         } else {
             return new SecretValue(value, secretType);
         }
+    }
+
+    public static byte[] asBytes(char[] chars) {
+        CharBuffer charBuffer = CharBuffer.wrap(chars);
+        ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
+        byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+
+        BestEffortShredder.shred(charBuffer.array());
+        BestEffortShredder.shred(byteBuffer.array());
+
+        return bytes;
     }
 }

--- a/sdk/src/test/java/com/schibsted/security/strongbox/sdk/SecretValueConverterTest.java
+++ b/sdk/src/test/java/com/schibsted/security/strongbox/sdk/SecretValueConverterTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Schibsted Products & Technology AS. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+ */
+
+package com.schibsted.security.strongbox.sdk;
+
+import com.schibsted.security.strongbox.sdk.internal.converter.SecretValueConverter;
+import org.testng.annotations.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author jwarlander
+ */
+public class SecretValueConverterTest {
+    @Test
+    public void chars_to_bytes() {
+        String str = "beeboopfoobarblahblahthisisalongstringyeah";
+        char[] charsFromString = str.toCharArray();
+        byte[] bytesFromString = str.getBytes(Charset.forName("UTF-8"));
+        assertThat(SecretValueConverter.asBytes(charsFromString), is(bytesFromString));
+
+        // Our initial char array above should be shredded now; eg. only nulls
+        char[] emptyCharArray = new char[bytesFromString.length];
+        assertThat(charsFromString, is(emptyCharArray));
+    }
+}


### PR DESCRIPTION
Depending on the length of input, it seems the backing byte array in the ByteBuffer that holds the UTF-8 encoded bytes has some zero-filled padding that gets included in the stored secret value:

```
$ /usr/bin/strongbox secret create --name my_secret --group etl --value-from-stdin
Enter secret value:
$ /usr/bin/strongbox --output=json secret get-latest-active --name=my_secret --group etl | jq '.[0].secretValue'
{
  "encoding": "utf8",
  "type": "opaque",
  "secretValue": "beeboopfoobarblahblahthisisalongstringyeah\u0000\u0000\u0000\u0000"
}
```

If we make sure to copy only up to the `limit` from the backing array, as per the proposed change, the outcome is better (as tested with a locally built client):

```
$ build/bin/strongbox secret add-version --name my_secret --group etl --value-from-stdin
Enter secret value:
$ /usr/bin/strongbox --output=json secret get-latest-active --name=my_secret --group etl | jq '.[0].secretValue'
{
  "encoding": "utf8",
  "type": "opaque",
  "secretValue": "beeboopfoobarblahblahthisisalongstringyeah"
}
```