### PR TITLE
Increment line number

### DIFF
--- a/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFile.java
+++ b/sdk/src/main/java/com/schibsted/security/strongbox/sdk/internal/config/AWSCLIConfigFile.java
@@ -59,6 +59,7 @@ public class AWSCLIConfigFile {
                     Section sectionToUpdate = sections.computeIfAbsent(currentSection.orElse(""), Section::new);
                     sectionToUpdate.addProperty(property);
                 }
+                lineNumber++;
             }
 
             return new Config(sections);


### PR DESCRIPTION
Ran into a small bug that held me up for bit.

With this config file (notice the space on the last line).
```
[default]
region = eu-west-1
 
```
It gave me an incorrect error message. Compare with PR version below.

```
$ strongbox group list
Failed to load config from '/Users/antsor2/.aws/config': Failed to interpret line #1 as 'key=value'. Please note that comment lines must start with '#'.
$ ./build/bin/strongbox group list
Failed to load config from '/Users/antsor2/.aws/config': Failed to interpret line #3 as 'key=value'. Please note that comment lines must start with '#'.
```