### PR TITLE
Revert previous workaround to get deployment to work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ env:
 deploy:
   # Documentation
   - provider: pages
-    edge:
-      branch: v1.8.47
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
     local_dir: build/gh-pages/

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,6 @@ deploy:
       branch: master
   # DEB
   - provider: bintray
-    edge:
-      branch: v1.8.47  
     file: "bintray/descriptor-deb.json"
     user: $BINTRAY_USER
     key: $BINTRAY_KEY
@@ -65,8 +63,6 @@ deploy:
       branch: master
   # RPM
   - provider: bintray
-    edge:
-      branch: v1.8.47  
     file: "bintray/descriptor-rpm.json"
     user: $BINTRAY_USER
     key: $BINTRAY_KEY
@@ -75,8 +71,6 @@ deploy:
       branch: master
  # Tarball
   - provider: bintray
-    edge:
-      branch: v1.8.47  
     file: "bintray/descriptor-tar.json"
     user: $BINTRAY_USER
     key: $BINTRAY_KEY


### PR DESCRIPTION
This PR reverts commits that was a workaround for travis-ci/travis-ci#9312. It now seems that this has made the build dependencies out of sync.