### PR TITLE
Remove Slack badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
   <a title="Stronbox Travis Build" href="https://travis-ci.org/schibsted/strongbox">
     <img src="https://api.travis-ci.org/schibsted/strongbox.svg?branch=master">
   </a>
-  <a title="Slack Status" href="https://slackin-bjmwohmllu.now.sh">
-    <img src="https://slackin-bjmwohmllu.now.sh/badge.svg">
-  </a>
   <a href="https://snyk.io/test/github/schibsted/strongbox"><img src="https://snyk.io/test/github/schibsted/strongbox/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/schibsted/strongbox" style="max-width:100%;"></a>
 </p>
 


### PR DESCRIPTION
This is a potential libability given how it's implemented,
and it adds little value.