### PR TITLE
Add jaxb-api as explicit dependency

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -38,6 +38,10 @@ FasterXML Jackson Core
   LICENSE: Apache 2.0,
            https://github.com/FasterXML/jackson-core
 
+JAXB
+  LICENSE: GPL 2.0 with Class-path Exception
+           https://github.com/javaee/jaxb-v2/blob/master/LICENSE
+
 # TRANSITIVE DEPENDENCIES FOR THE STRONGBOX SDK
 
 Amazon Ion Java
@@ -82,6 +86,10 @@ Apache HttpComponents Core
   LICENSE: Apache 2.0,
            https://github.com/apache/httpcomponents-core/blob/master/LICENSE.txt
   NOTICE:  https://github.com/apache/httpcomponents-core/blob/master/NOTICE.txt
+
+Activation
+  LICENSE: GPL 2.0 with Class-path Exception
+	   https://github.com/javaee/activation/blob/master/LICENSE.txt
 
 # ADDITIONAL STRONGBOX CLI DEPENDENCIES
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ allprojects {
         guavaVersion = '20.0'
         hamcrestVersion = '1.3'
         jacksonVersion = '2.8.9'
+        jaxbVersion = '2.3.1'
         mockitoVersion = '2.8.47'
         slf4jVersion = '1.7.25'
         springVersion = "4.2.6.RELEASE"
@@ -79,6 +80,9 @@ allprojects {
 }
 
 subprojects {
+    dependencies {
+        compile "javax.xml.bind:jaxb-api:$jaxbVersion"
+    }
     test {
         // enable TestNG support (default is JUnit)
         useTestNG()


### PR DESCRIPTION
This gives partial support for newer JVM's (no GUI support though). Successfully tested by runnning on openjdk 14.

Fixes #27.
Partially fixes #31.