### PR TITLE
Skip verification of JavaDoc and sources

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -10,6 +10,10 @@
       <ignored-keys>
          <ignored-key id="74dafdfd6dae2441" reason="Key couldn't be downloaded from any key server"/>
       </ignored-keys>
+      <trusted-artifacts>
+        <trust file=".*-javadoc[.]jar" regex="true"/>
+        <trust file=".*-sources[.]jar" regex="true"/>
+      </trusted-artifacts>
       <trusted-keys>
          <trusted-key id="015479e1055341431b4545ab72475fd306b9cab7" group="com.googlecode.javaewah" name="JavaEWAH" version="0.7.9"/>
          <trusted-key id="0785b3eff60b1b1bea94e0bb7c25280eae63ebe5" group="org.apache.httpcomponents"/>


### PR DESCRIPTION
IDEs fetch these by default. 

https://docs.gradle.org/6.9.3/userguide/dependency_verification.html#sec:skipping-javadocs