### PR TITLE
Make './gradlew build' work out of the box

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@
 #
 
 projectGroup=com.schibsted.security
+ossrhUsername=
+ossrhPassword=

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -87,6 +87,7 @@ artifacts {
 }
 
 signing {
+    required { version != '0.0.1' }
     sign configurations.archives
 }
 


### PR DESCRIPTION
 - Only sign SDK if the release version is set
 - Set empty creds for OSSRH